### PR TITLE
#178 implement xbox gamepad support

### DIFF
--- a/scripts/core/constants.py
+++ b/scripts/core/constants.py
@@ -133,3 +133,31 @@ class FontType(Enum):
 class FontEffects(IntEnum):
     FADE_IN = auto()
     FADE_OUT = auto()
+
+
+class GamepadButton(IntEnum):
+    UP = auto()
+    LEFT = auto()
+    DOWN = auto()
+    RIGHT = auto()
+    NORTH = auto()
+    EAST = auto()
+    SOUTH = auto()
+    WEST = auto()
+    SELECT_OR_BACK = auto()
+    START = auto()
+    LEFT_SHOULDER_1 = auto()
+    LEFT_SHOULDER_2 = auto()
+    RIGHT_SHOULDER_1 = auto()
+    RIGHT_SHOULDER_2 = auto()
+    LEFT_STICK = auto()
+    RIGHT_STICK = auto()
+
+
+class GamepadAxes(IntEnum):
+    LEFT_X = auto()
+    LEFT_Y = auto()
+    RIGHT_X = auto()
+    RIGHT_Y = auto()
+    DPAD_X = auto()
+    DPAD_Y = auto()

--- a/scripts/core/game.py
+++ b/scripts/core/game.py
@@ -43,6 +43,7 @@ class Game:
 
         # init libraries
         pygame.init()
+        pygame.joystick.init()
 
         # managers
         self.debug: Debugger = Debugger(self)

--- a/scripts/core/input.py
+++ b/scripts/core/input.py
@@ -1,16 +1,75 @@
 from __future__ import annotations
 
+import dataclasses
 import logging
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Mapping, Tuple
 
 import pygame
 from pygame.locals import *
+
+from .constants import GamepadAxes, GamepadButton
 
 if TYPE_CHECKING:
     from scripts.core.game import Game
 
 __all__ = ["Input"]
+
+
+@dataclasses.dataclass
+class ControllerConfig:
+   deadzone: float
+   axes: Mapping[int, GamepadAxes]
+   hat: Mapping[int, Tuple[GamepadButton, GamepadButton]]
+   buttons: Mapping[int, GamepadButton]
+
+# specific to xbox gamepad layout, should not be changed by player
+# add more configs for other gamepad types: ps3,4,5, switch, etc
+xbox_gamepad_config = ControllerConfig(
+    deadzone=.25,
+    axes={
+       0: GamepadAxes.LEFT_X,
+       1: GamepadAxes.LEFT_Y,
+       # 2: None,  # l. shoulder
+       3: GamepadAxes.RIGHT_X,
+       4: GamepadAxes.RIGHT_Y,
+       # 5: None,  # r. shoulder
+    },
+    hat={
+        0: (GamepadButton.LEFT, GamepadButton.RIGHT),
+        1: (GamepadButton.DOWN, GamepadButton.UP),
+    },
+    buttons={
+        0: GamepadButton.SOUTH,
+        1: GamepadButton.EAST,
+        2: GamepadButton.WEST,
+        3: GamepadButton.NORTH,
+        4: GamepadButton.LEFT_SHOULDER_1,
+        5: GamepadButton.RIGHT_SHOULDER_1,
+        6: GamepadButton.SELECT_OR_BACK,
+        7: GamepadButton.START,
+        8: GamepadButton.LEFT_STICK,
+        9: GamepadButton.RIGHT_STICK,
+    },
+)
+
+# generic mapping for gamepad buttons to game input labels
+# if the player wants to change config, this would need to be changed
+gamepad_label_map = {
+    GamepadButton.UP: "up",
+    GamepadButton.LEFT: "left",
+    GamepadButton.DOWN: "down",
+    GamepadButton.RIGHT: "right",
+    GamepadButton.EAST: "cancel",
+    GamepadButton.SOUTH: "select",
+    GamepadButton.NORTH: "view_troupe",
+}
+
+# map analog axis to digital buttons
+gamepad_axis_direction_map = {
+    GamepadAxes.LEFT_X: [GamepadButton.LEFT, GamepadButton.RIGHT],
+    GamepadAxes.LEFT_Y: [GamepadButton.UP, GamepadButton.DOWN],
+}
 
 
 class Input:
@@ -48,6 +107,9 @@ class Input:
 
         self.mouse_pos = [0, 0]
         self.mouse_pos_raw = self.mouse_pos.copy()
+
+        self.gamepads = dict()
+        self.scan_gamepads()
 
         # record duration
         end_time = time.time()
@@ -207,6 +269,57 @@ class Input:
                     if event.key == K_DOWN:
                         self.states["hold_down"] = False
 
+                if event.type == JOYBUTTONDOWN:
+                    button = xbox_gamepad_config.buttons[event.button]
+                    label = gamepad_label_map.get(button)
+                    if label:
+                        self.states[label] = True
+                        self.states["hold_" + label] = True
+
+                if event.type == JOYBUTTONUP:
+                    button = xbox_gamepad_config.buttons[event.button]
+                    label = gamepad_label_map.get(button)
+                    if label:
+                        self.states["hold_" + label] = False
+
+                if event.type == JOYHATMOTION:
+                    for axis, value in enumerate(event.value):
+                        endstops = xbox_gamepad_config.hat[axis]
+                        button = None
+                        if value == -1:
+                            button = endstops[0]
+                        elif value == 1:
+                            button = endstops[1]
+                        if button:
+                            label = gamepad_label_map[button]
+                            self.states[label] = True
+                            self.states["hold_" + label] = True
+                        else:
+                            for button in endstops:
+                                label = gamepad_label_map[button]
+                                self.states["hold_" + label] = False
+
+                if event.type == JOYAXISMOTION:
+                    axis = xbox_gamepad_config.axes[event.axis]
+                    endstops = gamepad_axis_direction_map.get(axis)
+                    if endstops is not None:
+                        if abs(event.value) >= xbox_gamepad_config.deadzone:
+                            button = None
+                            if event.value < 0:
+                                button = endstops[0]
+                            elif event.value > 0:
+                                button = endstops[1]
+                            if button:
+                                label = gamepad_label_map[button]
+                                hold_label = "hold_" + label
+                                if not self.states[hold_label]:
+                                    self.states[label] = True
+                                self.states[hold_label] = True
+                        else:
+                            for button in endstops:
+                                label = gamepad_label_map[button]
+                                self.states["hold_" + label] = False
+
             elif self.mode == "typing":
                 if event.type == KEYDOWN:
                     for char in chars:
@@ -222,3 +335,11 @@ class Input:
 
                     if event.key == K_SPACE:
                         self.char_buffer.append(" ")
+
+    def scan_gamepads(self):
+        for index in range(pygame.joystick.get_count()):
+            gamepad = pygame.joystick.Joystick(index)
+            gamepad.init()
+            # if the Joystick object is deleted, then event loop
+            # will not have joystick events, so we need to keep a ref.
+            self.gamepads[gamepad.get_guid()] = gamepad

--- a/scripts/core/input.py
+++ b/scripts/core/input.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import dataclasses
 import logging
 import time
-from typing import TYPE_CHECKING, Mapping, Tuple
+from typing import Mapping, Tuple, TYPE_CHECKING
 
 import pygame
 from pygame.locals import *
@@ -18,22 +18,23 @@ __all__ = ["Input"]
 
 @dataclasses.dataclass
 class ControllerConfig:
-   deadzone: float
-   axes: Mapping[int, GamepadAxes]
-   hat: Mapping[int, Tuple[GamepadButton, GamepadButton]]
-   buttons: Mapping[int, GamepadButton]
+    deadzone: float
+    axes: Mapping[int, GamepadAxes]
+    hat: Mapping[int, Tuple[GamepadButton, GamepadButton]]
+    buttons: Mapping[int, GamepadButton]
+
 
 # specific to xbox gamepad layout, should not be changed by player
 # add more configs for other gamepad types: ps3,4,5, switch, etc
 xbox_gamepad_config = ControllerConfig(
-    deadzone=.25,
+    deadzone=0.25,
     axes={
-       0: GamepadAxes.LEFT_X,
-       1: GamepadAxes.LEFT_Y,
-       # 2: None,  # l. shoulder
-       3: GamepadAxes.RIGHT_X,
-       4: GamepadAxes.RIGHT_Y,
-       # 5: None,  # r. shoulder
+        0: GamepadAxes.LEFT_X,
+        1: GamepadAxes.LEFT_Y,
+        # 2: None,  # l. shoulder
+        3: GamepadAxes.RIGHT_X,
+        4: GamepadAxes.RIGHT_Y,
+        # 5: None,  # r. shoulder
     },
     hat={
         0: (GamepadButton.LEFT, GamepadButton.RIGHT),


### PR DESCRIPTION
#178 

* gamepad must be connected before game starts
* only xbox 360 style (follows xinput) are supported currently
* no configuration gui
* other layouts can be added in input.py
* alalog stick is mapped to digital inputs

the game cannot currently handle analog controls, since the input "labels", "events?" are binary, either on or off.  so in combat, using the analog stick would be the same as the d pad.

as an aside, i didn't mess with the layout of the python code.  i think that sometime soon, maybe next gamepad feature, we should consider refactoring it because its getting pretty big.