### PR TITLE
Fixed GitHub action for Python linting

### DIFF
--- a/.github/workflows/lint_and_fix_py.yml
+++ b/.github/workflows/lint_and_fix_py.yml
@@ -1,78 +1,27 @@
-name: Lint Python
-
-on:
-  pull_request:
-    types: [opened, edited, synchronize, ready_for_review]
-
+name: Format Python code
+on: [pull_request]
 jobs:
-  job1:
-    # check if from main repo or fork
-    if: |
-      github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
-      && github.event.pull_request.draft == false
-    name: PR Review - Snayff
-    runs-on: windows-latest
-
+  build:
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2.3.4
-      with:
-        fetch-depth: 0
-        ref: ${{ github.event.pull_request.head.ref }}  # this doesnt work for forks
-
-    - uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Locate Pip Cache
-      id: pip-cache
-      run: echo "::set-output name=dir::$(pip cache dir)"
-
-    - name: Cache dependencies
-      id: cache
-      uses: actions/cache@v2
-      with:
-        path: ${{ steps.pip-cache.outputs.dir }}
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/poetry.lock') }}
-        restore-keys: ${{ runner.os }}-pip-
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade poetry
-        poetry config virtualenvs.create false
-        poetry install --no-root
-# not everyone is using type hinting
-#    - name: mypy Type Check
-#      if: always()
-#      run: |
-#        poetry run python -m mypy scripts/
-
-    - name: Format with isort
-      if: always()
-      run: |
-        cd scripts
-        poetry run python -m isort .
-        cd ..
-
-    - name: Lint with Black
-      if: always()
-      run: |
-        poetry run python -m black scripts/
-
-    - name: Update Git
-      if: github.repository == 'Snayff/nqp2'
-      run: |
-        git config --global user.name 'nqp2'
-        git config --global user.email 'snayff@users.noreply.github.com'
-        git diff --exit-code || git commit -am "ci lint and test"
-      # git commit -am "ci lint and test"
-
-    - name: Git Status Check
-      if: github.repository == 'Snayff/nqp2'
-      run: |
-        git status
-
-    - name: Push changes
-      if: github.repository == 'Snayff/nqp2'
-      run: |
-        git push
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install black and isort
+        run: pip install black isort
+      - name: Run black and isort
+        run: black --check scripts/ && isort --check-only scripts/
+      - name: If needed, commit black changes to the pull request
+        if: failure()
+        run: |
+          black scripts/
+          isort scripts/
+          git config --global user.name 'Snayff'
+          git config --global user.email 'Snayff@users.noreply.github.com'
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
+          git fetch
+          git checkout $GITHUB_HEAD_REF
+          git commit -am "Formatted Python code with black and isort"
+          git push

--- a/.github/workflows/lint_and_fix_py.yml
+++ b/.github/workflows/lint_and_fix_py.yml
@@ -16,12 +16,12 @@ jobs:
       - name: If needed, commit black changes to the pull request
         if: failure()
         run: |
-          black scripts/
-          isort scripts/
-          git config --global user.name 'Snayff'
-          git config --global user.email 'Snayff@users.noreply.github.com'
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
+          black "scripts/"
+          isort "scripts/"
+          git config --global user.name "Snayff"
+          git config --global user.email "Snayff@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY"
           git fetch
-          git checkout $GITHUB_HEAD_REF
+          git checkout "$GITHUB_HEAD_REF"
           git commit -am "Formatted Python code with black and isort"
           git push

--- a/scripts/core/game.py
+++ b/scripts/core/game.py
@@ -6,7 +6,6 @@ from typing import List, Optional
 
 import pygame as pygame
 
-from scripts.core.window import Window
 from scripts.core import utility
 from scripts.core.assets import Assets
 from scripts.core.base_classes.scene import Scene
@@ -16,6 +15,7 @@ from scripts.core.debug import Debugger
 from scripts.core.input import Input
 from scripts.core.memory import Memory
 from scripts.core.rng import RNG
+from scripts.core.window import Window
 from scripts.scenes.combat.scene import CombatScene
 from scripts.scenes.event.scene import EventScene
 from scripts.scenes.gallery.scene import GalleryScene

--- a/scripts/core/game.py
+++ b/scripts/core/game.py
@@ -6,6 +6,7 @@ from typing import List, Optional
 
 import pygame as pygame
 
+from scripts.core.window import Window
 from scripts.core import utility
 from scripts.core.assets import Assets
 from scripts.core.base_classes.scene import Scene
@@ -15,7 +16,6 @@ from scripts.core.debug import Debugger
 from scripts.core.input import Input
 from scripts.core.memory import Memory
 from scripts.core.rng import RNG
-from scripts.core.window import Window
 from scripts.scenes.combat.scene import CombatScene
 from scripts.scenes.event.scene import EventScene
 from scripts.scenes.gallery.scene import GalleryScene


### PR DESCRIPTION
Fixed the GitHub action that automatically formats Python code using black and isort.

- I used [this](https://github.com/psf/black/actions/runs/17913292/workflow) as a template for the new workflow so I didn't use some of what was previously in the [workflow file](https://github.com/Snayff/nqp2/blob/develop/.github/workflows/lint_and_fix_py.yml), let me know if there's something that I should restore.
- I tested it on a fork before creating a branch here, so I believe it will work as long as the Workflow permissions are set correctly.
- I purposefully put an import in the wrong order on this PR to test if isort will fix it.