### PR TITLE
Avoid lint action failing build when files need reformatting

### DIFF
--- a/.github/workflows/lint_and_fix_py.yml
+++ b/.github/workflows/lint_and_fix_py.yml
@@ -11,10 +11,16 @@ jobs:
           python-version: 3.8
       - name: Install black and isort
         run: pip install black isort
-      - name: Run black and isort
-        run: black --check scripts/ && isort --check-only scripts/
-      - name: If needed, commit black changes to the pull request
-        if: failure()
+      - name: Test if black and isort should reformat the scripts
+        id: black_isort_status
+        run: |
+          if black --check scripts/ && isort --check-only scripts/; then
+            echo "::set-output name=result::false"
+          else
+            echo "::set-output name=result::true"
+          fi
+      - name: If needed, commit black/isort changes to the pull request
+        if: steps.black_isort_status.outputs.result == 'true'
         run: |
           black "scripts/"
           isort "scripts/"

--- a/scripts/core/base_classes/scene.py
+++ b/scripts/core/base_classes/scene.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
-from scripts.core.constants import SceneType
 from scripts.core.base_classes.ui import UI
+from scripts.core.constants import SceneType
 
 if TYPE_CHECKING:
     from scripts.core.game import Game
@@ -17,8 +17,7 @@ class Scene(ABC):
     Handles Scene interactions and consolidates the rendering.
     """
 
-    def __init__(self,
-                 game: Game, scene_type: SceneType):
+    def __init__(self, game: Game, scene_type: SceneType):
         self.game: Game = game
 
         self.ui: UI = None  # ignore_type

--- a/scripts/core/base_classes/scene.py
+++ b/scripts/core/base_classes/scene.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
-from scripts.core.base_classes.ui import UI
 from scripts.core.constants import SceneType
+from scripts.core.base_classes.ui import UI
 
 if TYPE_CHECKING:
     from scripts.core.game import Game
@@ -17,7 +17,8 @@ class Scene(ABC):
     Handles Scene interactions and consolidates the rendering.
     """
 
-    def __init__(self, game: Game, scene_type: SceneType):
+    def __init__(self,
+                 game: Game, scene_type: SceneType):
         self.game: Game = game
 
         self.ui: UI = None  # ignore_type


### PR DESCRIPTION
The [previous pull request](https://github.com/Snayff/nqp2/pull/192#issuecomment-1008366286) added linting after PRs are submitted, but flags the build as failed when the step that checks if the files need linting return 1(which is expected and not a fail).

This PR should fix that by checking if the files need formatting using [set-output](https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions#setting-an-output-parameter) instead of `failure()`.