### PR TITLE
much better handling of room changes

### DIFF
--- a/scripts/scene_elements/world/model.py
+++ b/scripts/scene_elements/world/model.py
@@ -54,6 +54,15 @@ class WorldModel:
     def boundaries(self):
         return self.terrain.boundaries
 
+    @property
+    def next_boundaries(self):
+        # TODO: change this if rooms can move to other sides
+        return self.next_terrain.boundaries.move(self.boundaries.width, 0)
+
+    @property
+    def total_boundaries(self):
+        return self.boundaries.union(self.next_boundaries)
+
     def px_to_loc(self, pos: PointLike):
         """
         Convert map coordinates to tile coordinate

--- a/scripts/scenes/world/combat.py
+++ b/scripts/scenes/world/combat.py
@@ -83,7 +83,7 @@ class CombatController:
                 i.pos[0] += 5
 
             # TODO: find better way to calculate this value
-            final = self._game.window.base_resolution[0] + 320 + 100
+            final = self._game.window.base_resolution[0] + 320 + 320
             terrain_offset = self._game.window.base_resolution[0] + 320
 
             # this is a giant hack because the game only supports
@@ -99,7 +99,7 @@ class CombatController:
                     i.pos[0] -= terrain_offset
                 # TODO: decouple this
                 self._game.world.ui._worldview.clamp_primary_terrain = True
-                self._game.world.ui._worldview.camera.reset_movement()
+                self._game.world.ui._worldview.camera.move(-terrain_offset - 148, 0)
                 self._model.terrain.ignore_boundaries = False
                 self._model.next_terrain.ignore_boundaries = False
                 self._model.swap_terrains()


### PR DESCRIPTION
less obvious room changing glitches.  at this point, the effort into a work around would probably be greater than the effort to fix the root cause, so i'd like to leave it at this.  there is still a flash when the terrains/rooms are swapped, but the panning camera is less obvious.