### PR TITLE
fix/gridhover

### DIFF
--- a/scripts/scene_elements/world/view.py
+++ b/scripts/scene_elements/world/view.py
@@ -148,5 +148,4 @@ class WorldView:
 
         """
         offset = self.camera.render_offset()
-        # TODO: find out why coordinates are off by 10 on x axis
-        return pygame.Vector2(point) - offset + (10, 0)
+        return pygame.Vector2(point) - offset


### PR DESCRIPTION
manual offset was added during development to compensate for *something*, but after development finished, it was no longer needed and was causing problems.  removed.  unfortunately, im unsure why it was needed and hope that there isn't some interment issues causing the mouse x axis values to be wrong *sometimes*.