### PR TITLE
fix/bragan_crashing_game

### DIFF
--- a/data/items/bragans_item.yaml
+++ b/data/items/bragans_item.yaml
@@ -2,11 +2,11 @@
 name: Bragan's Signature Item
 is_signature: true
 effects:
-  - name: UnitsAttributeModifier
+  - name: AttributeModifierEffect
     unit_type: all
     attribute: upgrade_effectiveness
     mod_amount: 20%
-  - name: AddItem
+  - name: AddItemEffect
     item_type: gold
     item_count: 1000
     trigger: EnterNewRoom


### PR DESCRIPTION
Fixes the crashes that occur when selecting Bragan. The crashes happened because his data file was called `brangans_item.yaml` instead of  `bragans_item.yaml` and because both of his effect attributes were referencing non-existing effect names.