### PR TITLE
feature/lazy_loading_images

### DIFF
--- a/nqp/base_classes/resource_controller.py
+++ b/nqp/base_classes/resource_controller.py
@@ -1,0 +1,47 @@
+import weakref
+from typing import Callable
+
+
+class ResourceController:
+    """
+    Base class with a general specification for lazily loading game resources.
+
+    Resources in a ResourceController can be accessed just like in a dictionary.
+    """
+
+    def __init__(self, loader: Callable, is_weakref: bool):
+        """
+        Initialize a ResourceController.
+
+        :param loader: function used to create a new object. When it does not exist,
+        the loader function gets called with the key passed to the controller as an
+        argument.
+        :param is_weakref: weakref is used to allow garbage collecting values that are no longer used
+        even if they are referenced by the dictionary, meaning the cache dictionary
+        does not increase the reference count for its values, so they get can be
+        released from memory when not referenced elsewhere.
+        """
+        self.cache = weakref.WeakValueDictionary() if is_weakref else dict()
+        self.loader = loader
+
+    def __setitem__(self, name, value):
+        """
+        Set value for a name in the dictionary
+        :param name: the key that's getting its value set
+        :param value: the new value for it
+        """
+        self.cache[name] = value
+
+    def __getitem__(self, name):
+        """
+        Get items from a ResourceController like it's a dictionary
+        :param name: the key used to access a resource
+        :return: the item already in cache or the item that didn't exist and was loaded
+        """
+        try:
+            img = self.cache[name]
+        except KeyError:
+            img = self.loader(name)
+            self.cache[name] = img
+
+        return img

--- a/nqp/core/visual.py
+++ b/nqp/core/visual.py
@@ -11,6 +11,7 @@ from nqp.base_classes.image import Image
 from nqp.core.constants import ASSET_PATH, DEFAULT_IMAGE_SIZE, FontEffects, FontType, IMG_FORMATS
 from nqp.core.debug import Timer
 from nqp.core.utility import clamp, clip
+from nqp.resource_controllers.image_resource_controller import ImageResourceController
 from nqp.ui_elements.generic.fancy_font import FancyFont
 from nqp.ui_elements.generic.font import Font
 
@@ -65,7 +66,7 @@ class Visual:
                 for tileset in os.listdir(ASSET_PATH / "tiles")
             }
 
-            self._images: Dict[str, pygame.Surface] = self._load_images()  # image_name: surface
+            self._images: ImageResourceController = ImageResourceController(self._image_folders)
             self._animation_frames: Dict[str, Dict[str, List[Image]]] = self._load_animation_frames()
             # folder_name: {frame_name, [animation_frames]}
             self._fonts: Dict[FontType, Tuple[str, Tuple[int, int, int]]] = self._load_fonts()  # FontType: path, colour
@@ -94,47 +95,6 @@ class Visual:
             FontType.INSTRUCTION: (str(ASSET_PATH / "fonts/small_font.png"), (240, 205, 48)),
             FontType.NOTIFICATION: (str(ASSET_PATH / "fonts/large_font.png"), (117, 50, 168)),
         }
-
-    def _load_images(self) -> Dict[str, pygame.Surface]:
-        """
-        Load all images specified in self._image_folders
-        """
-        images = {}
-        folders = self._image_folders
-        counter = 0
-
-        for folder in folders:
-            path = ASSET_PATH / folder
-            for image_name in os.listdir(path):
-                if image_name.split(".")[-1] in IMG_FORMATS:
-
-                    # warn about duplicates
-                    if image_name in images.keys():
-                        logging.warning(f"{image_name} already loaded, non-unique file name.")
-
-                    # load image
-                    image = pygame.image.load(str(path / image_name)).convert_alpha()
-
-                    # store image
-                    width = image.get_width()
-                    height = image.get_height()
-                    images[f"{image_name.split('.')[0]}@{width}x{height}"] = image  # split to remove extension
-
-                    counter += 1
-
-        # add not found image
-        image = pygame.image.load(str(ASSET_PATH / "debug/image_not_found.png")).convert_alpha()
-        images[f"not_found@{DEFAULT_IMAGE_SIZE}x{DEFAULT_IMAGE_SIZE}"] = image
-
-        counter += 1
-        logging.debug(f"Visual: {counter} Images loaded.")
-
-        # add transparent surface
-        image = pygame.Surface((DEFAULT_IMAGE_SIZE, DEFAULT_IMAGE_SIZE))
-        image.set_alpha(0)
-        images[f"blank@{DEFAULT_IMAGE_SIZE}x{DEFAULT_IMAGE_SIZE}"] = image
-
-        return images
 
     def _load_animation_frames(self) -> Dict[str, Dict[str, List[Image]]]:
         """

--- a/nqp/resource_controllers/image_resource_controller.py
+++ b/nqp/resource_controllers/image_resource_controller.py
@@ -1,0 +1,89 @@
+import logging
+from pathlib import Path
+from typing import List
+
+import pygame
+
+from nqp.base_classes.resource_controller import ResourceController
+from nqp.core.constants import ASSET_PATH, DEFAULT_IMAGE_SIZE, IMG_FORMATS
+
+
+class ImageResourceController(ResourceController):
+    """
+    Controls lazy loading for images
+    """
+
+    def __init__(self, image_folders: List[str]):
+        """
+        Initialize the super class without using weakref to avoid reloading images that don't
+        always keep references in the Scene and would need to reload many times. It'd be better
+        to use weakref but that would require images to be manually referenced at the Scene to
+        keep them from having to reload.
+        """
+        ResourceController.__init__(self, loader=self._load_image, is_weakref=False)
+
+        self._initialize_image_name_to_path_dict(image_folders)
+        self._add_blank_surface_to_cache()
+
+    def _initialize_image_name_to_path_dict(self, image_folders: List[str]) -> None:
+        """
+        Initialize a dictionary attribute mapping each image name to its path in disk
+        :param image_folders: list of folders with image assets
+        """
+
+        # Convert string paths to Path objects
+        image_folders_paths = [Path(ASSET_PATH / image_path) for image_path in image_folders]
+
+        # Map each image name(without extension) to its file path
+        name_to_path = {
+            image_name.stem: image_path / image_name
+            for image_path in image_folders_paths
+            for image_name in image_path.iterdir()
+            if image_name.suffix.lower()[1:] in IMG_FORMATS
+        }
+
+        # Include the path of the image used when an image is not found
+        name_to_path["not_found"] = ASSET_PATH / "debug" / "image_not_found.png"
+
+        self._image_name_to_path_dict = name_to_path
+
+    def _add_blank_surface_to_cache(self) -> None:
+        """
+        Add the "blank" image to the cache with a blank alpha image
+        """
+
+        blank_size = DEFAULT_IMAGE_SIZE, DEFAULT_IMAGE_SIZE
+
+        self._blank_surface = pygame.Surface(blank_size, pygame.SRCALPHA).convert_alpha()
+
+        if self._blank_surface.get_size() != blank_size:
+            self._blank_surface = pygame.transform.scale(self._blank_surface, blank_size)
+
+        self.cache["blank"] = self._blank_surface
+
+    def _load_image(self, item: str) -> pygame.Surface:
+        """
+        Load a new image from the passed item.
+
+        :param item: a string specifying the image's name and resolution, formatted as file@WidthxHeight,
+        such as town@640.0x360.0
+        :return: a Surface with the loaded image.
+        """
+        logging.info(f"Loading image '{item}'")
+
+        # The image's name is before the at sign, width and height are after
+        name, after_at_sign = item.split("@")
+
+        """
+        Width and height are strings formatted as floats so we get each string by splitting at "x",
+        convert each to float then to int to later compare with the integer size of the surface
+        """
+        expected_size = list(map(int, map(float, after_at_sign.split("x"))))
+
+        surface = pygame.image.load(self._image_name_to_path_dict[name]).convert_alpha()
+
+        if surface.get_size() != expected_size:
+            logging.debug(f"Image had to be rescaled from {surface.get_size()} to {expected_size}")
+            surface = pygame.transform.scale(surface, expected_size)
+
+        return surface


### PR DESCRIPTION
Implemented lazy loading for images and a base ResourceController class for handling general lazy loading, to facilitate implementation with other resources if we decide to use lazy loading for them as well.

I decided to not use weakref for the image class as it would require changes in scenes to keep images from having to repeatedly load, but it would be more memory efficient to use that in the future and then just reference the necessary resources in the Scene to keep them from loading while still releasing them from memory when the scene is over.

With the way I did it, the images are always kept in memory after loading for the first time. 

Closes #318.