### PR TITLE
skip loading item effects until item is in play

### DIFF
--- a/nqp/core/data.py
+++ b/nqp/core/data.py
@@ -356,7 +356,5 @@ class Data:
             name=item_data.name,
             is_signature=item_data.is_signature,
         )
-        effects = [self.create_effect(data, item) for data in item_data.effects]
-        components = [item] + effects
-        entity = snecs.new_entity(components)
+        entity = snecs.new_entity((item,))
         return entity

--- a/tests/npq/core/test_effect.py
+++ b/tests/npq/core/test_effect.py
@@ -134,10 +134,10 @@ class EffectTestCase(unittest.TestCase):
     def test_item_no_errors(self):
         item = self.data.create_item("albroms_item")
         item = self.data.create_item("bragans_item")
-        # item = self.data.create_item("lurents_item")
-        # item = self.data.create_item("ralnaths_item")
-        # item = self.data.create_item("sildreths_item")
-        # item = self.data.create_item("thracks_item")
+        item = self.data.create_item("lurents_item")
+        item = self.data.create_item("ralnaths_item")
+        item = self.data.create_item("sildreths_item")
+        item = self.data.create_item("thracks_item")
 
     def test_fire(self):
         snecs.add_component(self.entity_id0, OnFireStatusEffect())


### PR DESCRIPTION
item effects should be loaded when the commander is in play.  thats not ready yet, so this change just prevents them from loading at all.