### PR TITLE
fix pathfinding

### DIFF
--- a/nqp/command/unit.py
+++ b/nqp/command/unit.py
@@ -34,7 +34,7 @@ class Unit:
         self.is_selected: bool = False
         self.entities: List[EntityID] = []
 
-        self.entity_spread_max = unit_data["entity_spread"] if "entity_spread" in unit_data else 48
+        self.entity_spread_max = unit_data["entity_spread"] if "entity_spread" in unit_data else 24
         self.count: int = unit_data["count"] + base_values["count"]  # number of entities spawned
         self.gold_cost: int = unit_data["gold_cost" ""] + base_values["gold_cost"]
         self._banner_image = self._game.visual.get_image("banner")

--- a/nqp/core/components.py
+++ b/nqp/core/components.py
@@ -47,19 +47,19 @@ class Position(RegisteredComponent):
         return Position(pos)
 
     @property
-    def x(self) -> int:
-        return int(self.pos.x)
+    def x(self) -> float:
+        return self.pos.x
 
     @x.setter
-    def x(self, value: int):
+    def x(self, value: int | float):
         self.pos = pygame.Vector2(value, self.pos.y)
 
     @property
-    def y(self) -> int:
-        return int(self.pos.y)
+    def y(self) -> float:
+        return self.pos.y
 
     @y.setter
-    def y(self, value: int):
+    def y(self, value: int | float):
         self.pos = pygame.Vector2(self.pos.x, value)
 
 

--- a/nqp/core/systems.py
+++ b/nqp/core/systems.py
@@ -130,6 +130,10 @@ def process_movement(delta_time: float, game: Game):
             continue
         if ai.behaviour.state not in ["path", "path_fast"]:
             continue
+        if ai.behaviour.state == "path_fast":
+            stats.move_speed.override(100)
+        elif ai.behaviour.state == "path":
+            stats.move_speed.reset()
 
         move_result = _walk_path(delta_time, position, stats, ai, game)
 

--- a/nqp/topography/pathfinding.py
+++ b/nqp/topography/pathfinding.py
@@ -55,10 +55,8 @@ def search_terrain(terrain, start, end):
 
     while queue:
         current = queue.get()
-
         if current == end:
             break
-
         for neighbor in terrain.get_exits(current):
             cost = cost_so_far[current] + terrain.cost(current, neighbor)
             if neighbor not in cost_so_far or cost < cost_so_far[neighbor]:

--- a/nqp/topography/terrain.py
+++ b/nqp/topography/terrain.py
@@ -197,6 +197,7 @@ class Terrain:
         Pathfind between map coordinates ("pixel coordinates")
 
         """
+        # offset is used so units pathfind to the center of a tile
         offset = pygame.Vector2(TILE_SIZE) / 2
         path_px = []
         for loc in self.pathfind(self.px_to_loc(start), self.px_to_loc(end)):

--- a/nqp/ui_elements/tailored/unit_grid.py
+++ b/nqp/ui_elements/tailored/unit_grid.py
@@ -119,11 +119,11 @@ class UnitGrid:
         target_px = dest.rect.center
         leader = unit.behaviour.leader
         leader_behaviour = snecs.entity_component(leader, AI).behaviour
-        leader_behaviour.current_path = [target_px]
+        leader_behaviour.target_position = pygame.Vector2(target_px)
         leader_behaviour.state = "path_fast"
         for entity in unit.entities[1:]:
             behaviour = snecs.entity_component(entity, AI).behaviour
-            behaviour.current_path = [target_px]
+            behaviour.target_position = pygame.Vector2(target_px)
             behaviour.state = "path_fast"
 
     def _swap_cells(self, a: GridCell, b: GridCell):
@@ -162,12 +162,12 @@ class UnitGrid:
                 target_px = cell.rect.center
                 leader = unit.entities[0]
                 behaviour = snecs.entity_component(leader, AI).behaviour
-                behaviour.current_path = [target_px]
+                behaviour.target_position = pygame.Vector2(target_px)
                 behaviour.state = "path_fast"
 
                 for entity in unit.entities[1:]:
                     behaviour = snecs.entity_component(entity, AI).behaviour
-                    behaviour.current_path = [target_px]
+                    behaviour.target_position = pygame.Vector2(target_px)
                     behaviour.state = "path_fast"
                 break
 

--- a/tests/npq/topography/test_topography.py
+++ b/tests/npq/topography/test_topography.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 from pygame import Vector2
 
 from nqp.topography.pathfinding import PriorityQueue
+from nqp.topography.terrain import Terrain
 
 
 class TestPriorityQueue(unittest.TestCase):
@@ -73,20 +74,16 @@ class TestPriorityQueue(unittest.TestCase):
 
 class TestSearchTerrain(unittest.TestCase):
     def setUp(self):
-        from nqp.topography.terrain import Terrain
-
         self.t = Terrain(Mock(), "biome")
 
-    @unittest.skip("broken")
     def test_search_endpoints_px(self):
         # changes to TILE_SIZE will fail this test
-        start = Vector2(8, 16)
+        start = Vector2(8, 15)
         end = Vector2(96, 96)
         result = self.t.pathfind_px(start, end)
-        self.assertEqual((0, 16), tuple(result[0]))
-        self.assertEqual((96, 96), tuple(result[-1]))
+        self.assertEqual((8, 24), tuple(result[0]))
+        self.assertEqual((104, 104), tuple(result[-1]))
 
-    @unittest.skip("broken")
     def test_search_path_px(self):
         # changes to TILE_SIZE will fail this test
         # Changes to pathfinding may cause test to fail even if path is valid
@@ -95,18 +92,18 @@ class TestSearchTerrain(unittest.TestCase):
         result = self.t.pathfind_px(start, end)
         result = list(map(tuple, result))
         expected = [
-            (0.0, 16.0),
-            (0.0, 32.0),
-            (0.0, 48.0),
-            (0.0, 64.0),
-            (0.0, 80.0),
-            (0.0, 96.0),
-            (16.0, 96.0),
-            (32.0, 96.0),
-            (48.0, 96.0),
-            (64.0, 96.0),
-            (80.0, 96.0),
-            (96.0, 96.0),
+            (8.0, 24.0),
+            (8.0, 40.0),
+            (8.0, 56.0),
+            (8.0, 72.0),
+            (8.0, 88.0),
+            (8.0, 104.0),
+            (24.0, 104.0),
+            (40.0, 104.0),
+            (56.0, 104.0),
+            (72.0, 104.0),
+            (88.0, 104.0),
+            (104.0, 104.0),
         ]
         self.assertEqual(expected, result)
 


### PR DESCRIPTION
misc fixes so pathfinding works again.  only tested with the unit grid.
- the position component must support floats, otherwise small movements and a fast framerate will prevent value from becoming larger that 1 greater that the previous result, leading to no movement after float values are truncated to int
- tests were using old data
- pathfinding target positions were using wrong data type (list v. Vector2)